### PR TITLE
[317] Fix broken citations on bubble map

### DIFF
--- a/production/html/bubblemap.html
+++ b/production/html/bubblemap.html
@@ -344,32 +344,6 @@
     //-->
     </script>
 	
-	<script type="text/javascript" language="JavaScript"><!--
-	var api;
-  
-	function HideContent(d) {
-	  document.getElementById(d).style.display = "none";
-	}
-	function ShowContent(d) {
-	  document.getElementById(d).style.display = "block";
-	}
-	function ReverseDisplay(d) {
-	  if(document.getElementById(d).style.display == "none") { document.getElementById(d).style.display = "block"; }
-	  else { document.getElementById(d).style.display = "none"; }
-/*	  var cartodb_popup = $("#map").find(".cartodb-popup-content");
-	  console.log(cartodb_popup);
-	  var element = cartodb_popup.jScrollPane();
-	  api = element.data('jsp');
-	  console.log(api); */
-	  api.reinitialise({
-            maintainPosition:       true,
-            verticalDragMinHeight:  20
-          }); 
-	}
-	//--></script>
-
-
-	
     <script>
       // create layer selector
       function createSelector(layer) {
@@ -378,8 +352,6 @@
         var $options = $('#controlbar input');
         $options.click(function(e) {        
 		  updateQuery(layer, $("#slider").rangeSlider("values"));
-//		  $("#slider").show();
-//		  $("#slider").rangeSlider("resize");
         });
 		$("#slider").bind("valuesChanged", function(e, data) {
 		  if ($("#controlbar input:checked").length > 0) {}
@@ -412,9 +384,9 @@
 		var query;
 		
 		if($('#relationship_3').is(':checked')) {
-		  query = "SELECT DISTINCT cities.*, Sum(jc.selected_number) AS selected_number, String_agg(jc.selected_names, '</p>') AS selected_names, String_agg(jc.selected_sources, '</p>') AS selected_sources, 'NON-NATIVE LYRIC ACTIVITY IN ' AS relationship_text_1, '' AS relationship_text_2 FROM cities,(SELECT r.cityid, Count(r.cityid) AS selected_number, (string_agg('<span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.poet_name, ', ' order BY r.poets_cities_rank)) AS selected_names, ('<h4 style=\"color:#AAAAAA\">Non-native Poets</h4>'||string_agg('<p><span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.details_name||'<br>Dates: '||r.dates||'<br>Genre(s): '||r.gn||'<br>Source(s): '||r.sources||'<br><a href=\"javascript:ReverseDisplay(''citation_o'||r.poets_cities_rank||''')\">Citation</a>'||'<br><span id=\"citation_o'||r.poets_cities_rank||'\" style=\"display:none;\">'||r.source_citation||': \"'||r.source_translation||'\" (trans. '||r.source_translator||')<br>'||r.source_greektext||'</span>' , '</p>' ORDER BY r.poets_cities_rank)) AS selected_sources FROM cities,(SELECT pp.*, rank() OVER (partition BY pp.cityid ORDER BY pp.poet_name ASC) AS poets_cities_rank FROM(SELECT DISTINCT pp.* FROM(SELECT poets.poetid, poets.poet_name, poets.details_name, poets.sources, poets.gn, poets.dates, poets_cities.cityid, poets_cities.source_citation, poets_cities.source_explicit, poets_cities.source_greektext, poets_cities.source_notes, poets_cities.source_translation, poets_cities.source_translator, poets_cities.source_work FROM(SELECT poets.*, COALESCE(poets_genres.gn, 'Unknown') AS gn FROM poets LEFT OUTER JOIN(SELECT sg.poetid, string_agg(sg.genre, ', ') AS gn FROM(SELECT * FROM genres WHERE genreid IN ('2','3','4','5','16','18','6','22','11','24','7','8','13','9','10','12','30','31','32') ORDER BY (genreid=32) DESC, (genreid=30) DESC, genre) sg GROUP BY sg.poetid)poets_genres ON poets.poetid=poets_genres.poetid) poets, poets_cities WHERE poets.poetid=poets_cities.poetid AND(poets_cities.nativeid=2 OR poets_cities.nativeid=3) ORDER BY poet_name ASC)pp, dates WHERE pp.poetid=dates.poetid AND (dates.date <= ";
+		  query = "SELECT DISTINCT cities.*, Sum(jc.selected_number) AS selected_number, String_agg(jc.selected_names, '</p>') AS selected_names, String_agg(jc.selected_sources, '</p>') AS selected_sources, 'NON-NATIVE LYRIC ACTIVITY IN ' AS relationship_text_1, '' AS relationship_text_2 FROM cities,(SELECT r.cityid, Count(r.cityid) AS selected_number, (string_agg('<span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.poet_name, ', ' order BY r.poets_cities_rank)) AS selected_names, ('<h4 style=\"color:#AAAAAA\">Non-native Poets</h4>'||string_agg('<p><span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.details_name||'<br>Dates: '||r.dates||'<br>Genre(s): '||r.gn||'<br>Source(s): '||r.sources||'<br><a id=\"link_to_citation_'||r.poets_cities_rank||'\" href=\"\" >Citation</a>'||'<br><span id=\"citation_'||r.poets_cities_rank||'\" style=\"display:none;\">'||r.source_citation||': \"'||r.source_translation||'\" (trans. '||r.source_translator||')<br>'||r.source_greektext||'</span>' , '</p>' ORDER BY r.poets_cities_rank)) AS selected_sources FROM cities,(SELECT pp.*, rank() OVER (partition BY pp.cityid ORDER BY pp.poet_name ASC) AS poets_cities_rank FROM(SELECT DISTINCT pp.* FROM(SELECT poets.poetid, poets.poet_name, poets.details_name, poets.sources, poets.gn, poets.dates, poets_cities.cityid, poets_cities.source_citation, poets_cities.source_explicit, poets_cities.source_greektext, poets_cities.source_notes, poets_cities.source_translation, poets_cities.source_translator, poets_cities.source_work FROM(SELECT poets.*, COALESCE(poets_genres.gn, 'Unknown') AS gn FROM poets LEFT OUTER JOIN(SELECT sg.poetid, string_agg(sg.genre, ', ') AS gn FROM(SELECT * FROM genres WHERE genreid IN ('2','3','4','5','16','18','6','22','11','24','7','8','13','9','10','12','30','31','32') ORDER BY (genreid=32) DESC, (genreid=30) DESC, genre) sg GROUP BY sg.poetid)poets_genres ON poets.poetid=poets_genres.poetid) poets, poets_cities WHERE poets.poetid=poets_cities.poetid AND(poets_cities.nativeid=2 OR poets_cities.nativeid=3) ORDER BY poet_name ASC)pp, dates WHERE pp.poetid=dates.poetid AND (dates.date <= ";
 		  query = query + -dateValues.min + " AND dates.date >= " + -dateValues.max;
-		  query = query + "))pp ORDER BY pp.cityid, pp.poet_name) r WHERE cities.cityid=r.cityid GROUP BY r.cityid, cities.city_name UNION ALL SELECT r.cityid, count(r.cityid) AS selected_number, ('<h4 style=\"color:#AAAAAA\">NATIVE LYRIC ACTIVITY IN '||cities.city_name||'</h4><p>'||string_agg('<span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.poet_name, ', ' ORDER BY r.poets_cities_rank)) AS selected_names, ('<h4 style=\"color:#AAAAAA\">Native poets</h4>'||string_agg('<p><span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.details_name||'<br>Dates: '||r.dates||'<br>Genre(s): '||r.gn||'<br>Source(s): '||r.sources||'<br><a href=\"javascript:ReverseDisplay(''citation_b'||r.poets_cities_rank||''')\">Citation</a>'||'<br><span id=\"citation_b'||r.poets_cities_rank||'\" style=\"display:none;\">'||r.source_citation||': \"'||r.source_translation||'\" (trans. '||r.source_translator||')<br>'||r.source_greektext||r.abc||'</span>' , '</p>' ORDER BY r.poets_cities_rank)) AS selected_sources FROM cities,(SELECT pp.*, rank() OVER (partition BY pp.cityid ORDER BY pp.poet_name ASC) AS poets_cities_rank FROM(SELECT DISTINCT pp.* FROM(SELECT poets.poetid, poets.poet_name, poets.details_name, poets.sources, poets.gn, poets.dates, poets_cities.cityid, poets_cities.source_citation, poets_cities.source_explicit, poets_cities.source_greektext, poets_cities.source_notes, poets_cities.source_translation, poets_cities.source_translator, poets_cities.source_work, poets_cities.abc FROM(SELECT poets.*, COALESCE(poets_genres.gn, 'Unknown') AS gn FROM poets LEFT OUTER JOIN(SELECT sg.poetid, string_agg(sg.genre, ', ') AS gn FROM(SELECT * FROM genres WHERE genreid IN ('2','3','4','5','16','18','6','22','11','24','7','8','13','9','10','12','30','31','32') ORDER BY (genreid=32) DESC, (genreid=30) DESC, genre) sg GROUP BY sg.poetid)poets_genres ON poets.poetid=poets_genres.poetid) poets,(SELECT poets_cities.*, COALESCE(abc.abc, '') AS abc FROM poets_cities LEFT OUTER JOIN(SELECT poets_cities.poetid, poets_cities.cityid, ('<br>See also: '||string_agg(bc.city_name, ', ' ORDER BY bc.city_name ASC)) AS abc FROM(SELECT * FROM poets_cities WHERE poets_cities.nativeid=1) poets_cities,(SELECT cities.city_name, poets_cities.cityid, poets_cities.poetid FROM cities, poets_cities WHERE cities.cityid=poets_cities.cityid AND poets_cities.nativeid=1)bc WHERE poets_cities.poetid=bc.poetid AND poets_cities.cityid != bc.cityid GROUP BY poets_cities.poetid, poets_cities.cityid) abc ON poets_cities.poetid=abc.poetid AND poets_cities.cityid=abc.cityid)poets_cities WHERE poets.poetid=poets_cities.poetid AND(poets_cities.nativeid=1) ORDER BY poet_name ASC)pp, dates WHERE pp.poetid=dates.poetid AND (dates.date <= "
+		  query = query + "))pp ORDER BY pp.cityid, pp.poet_name) r WHERE cities.cityid=r.cityid GROUP BY r.cityid, cities.city_name UNION ALL SELECT r.cityid, count(r.cityid) AS selected_number, ('<h4 style=\"color:#AAAAAA\">NATIVE LYRIC ACTIVITY IN '||cities.city_name||'</h4><p>'||string_agg('<span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.poet_name, ', ' ORDER BY r.poets_cities_rank)) AS selected_names, ('<h4 style=\"color:#AAAAAA\">Native poets</h4>'||string_agg('<p><span style=\"color:#B81609\">'||r.poets_cities_rank||'</span>. '||r.details_name||'<br>Dates: '||r.dates||'<br>Genre(s): '||r.gn||'<br>Source(s): '||r.sources||'<br><a id=\"link_to_citation_'||r.poets_cities_rank||'\" href=\"\" >Citation</a>'||'<br><span id=\"citation_b'||r.poets_cities_rank||'\" style=\"display:none;\">'||r.source_citation||': \"'||r.source_translation||'\" (trans. '||r.source_translator||')<br>'||r.source_greektext||r.abc||'</span>' , '</p>' ORDER BY r.poets_cities_rank)) AS selected_sources FROM cities,(SELECT pp.*, rank() OVER (partition BY pp.cityid ORDER BY pp.poet_name ASC) AS poets_cities_rank FROM(SELECT DISTINCT pp.* FROM(SELECT poets.poetid, poets.poet_name, poets.details_name, poets.sources, poets.gn, poets.dates, poets_cities.cityid, poets_cities.source_citation, poets_cities.source_explicit, poets_cities.source_greektext, poets_cities.source_notes, poets_cities.source_translation, poets_cities.source_translator, poets_cities.source_work, poets_cities.abc FROM(SELECT poets.*, COALESCE(poets_genres.gn, 'Unknown') AS gn FROM poets LEFT OUTER JOIN(SELECT sg.poetid, string_agg(sg.genre, ', ') AS gn FROM(SELECT * FROM genres WHERE genreid IN ('2','3','4','5','16','18','6','22','11','24','7','8','13','9','10','12','30','31','32') ORDER BY (genreid=32) DESC, (genreid=30) DESC, genre) sg GROUP BY sg.poetid)poets_genres ON poets.poetid=poets_genres.poetid) poets,(SELECT poets_cities.*, COALESCE(abc.abc, '') AS abc FROM poets_cities LEFT OUTER JOIN(SELECT poets_cities.poetid, poets_cities.cityid, ('<br>See also: '||string_agg(bc.city_name, ', ' ORDER BY bc.city_name ASC)) AS abc FROM(SELECT * FROM poets_cities WHERE poets_cities.nativeid=1) poets_cities,(SELECT cities.city_name, poets_cities.cityid, poets_cities.poetid FROM cities, poets_cities WHERE cities.cityid=poets_cities.cityid AND poets_cities.nativeid=1)bc WHERE poets_cities.poetid=bc.poetid AND poets_cities.cityid != bc.cityid GROUP BY poets_cities.poetid, poets_cities.cityid) abc ON poets_cities.poetid=abc.poetid AND poets_cities.cityid=abc.cityid)poets_cities WHERE poets.poetid=poets_cities.poetid AND(poets_cities.nativeid=1) ORDER BY poet_name ASC)pp, dates WHERE pp.poetid=dates.poetid AND (dates.date <= "
 		  query=query + -dateValues.min + " AND dates.date >= " + -dateValues.max;
 		  query=query + "))pp ORDER BY pp.cityid, pp.poet_name) r WHERE cities.cityid=r.cityid GROUP BY r.cityid, cities.city_name) jc WHERE cities.cityid=jc.cityid GROUP BY cities.cityid, cities.cartodb_id, cities.the_geom, cities.the_geom_webmercator, cities.infowindow_name";
 		}
@@ -427,7 +399,7 @@
 			  }
 		  }
 		  if(firstCall==true) {
-			  query = "SELECT cities.*, Count(rank_players.cityid) AS selected_number, (string_agg('<span style=\"color:#B81609\">' || rank_players.poets_cities_rank || '</span>. ' || rank_players.poet_name, ', ' order BY rank_players.poets_cities_rank)) AS selected_names, (string_agg('<p><span style=\"color:#B81609\">' || rank_players.poets_cities_rank || '</span>. ' || rank_players.details_name || '<br>Dates: ' || rank_players.date_names || '<br>Genre(s): ' || rank_players.gn || '<br>Source(s): ' || rank_players.sources || '<br><a href=\"javascript:ReverseDisplay(''citation' || rank_players.poets_cities_rank || ''')\">Citation</a>' || '<br><span id=\"citation' || rank_players.poets_cities_rank || '\" style=\"display:none;\">' || rank_players.source_citation || ': \"' || rank_players.source_translation || '\" (trans. ' || rank_players.source_translator || ')<br>' || rank_players.source_greektext || rank_players.alternative_birth_cities || '</span>' , '</p>' ORDER BY rank_players.poets_cities_rank)) AS selected_sources, ";
+			  query = "SELECT cities.*, Count(rank_players.cityid) AS selected_number, (string_agg('<span style=\"color:#B81609\">' || rank_players.poets_cities_rank || '</span>. ' || rank_players.poet_name, ', ' order BY rank_players.poets_cities_rank)) AS selected_names, (string_agg('<p><span style=\"color:#B81609\">' || rank_players.poets_cities_rank || '</span>. ' || rank_players.details_name || '<br>Dates: ' || rank_players.date_names || '<br>Genre(s): ' || rank_players.gn || '<br>Source(s): ' || rank_players.sources || '<br><a id=\"link_to_citation_'||r.poets_cities_rank||'\" href=\"\" >Citation</a>' || '<br><span id=\"citation' || rank_players.poets_cities_rank || '\" style=\"display:none;\">' || rank_players.source_citation || ': \"' || rank_players.source_translation || '\" (trans. ' || rank_players.source_translator || ')<br>' || rank_players.source_greektext || rank_players.alternative_birth_cities || '</span>' , '</p>' ORDER BY rank_players.poets_cities_rank)) AS selected_sources, ";
 
 		  }
   
@@ -612,13 +584,42 @@
 		  ].join("");
 		}
 		
-		console.log(query);		
 		layer.setQuery(query); 
 		layer.setCartoCSS("#cities{ marker-fill: #B81609; marker-line-color: #FFF; marker-line-width: 2; marker-line-opacity: 1; marker-opacity: 0.9; marker-placement: point; marker-type: ellipse; marker-allow-overlap: true; marker-clip: false; marker-multi-policy: largest; } #cities [ selected_number <= 200] { marker-width: 28.0; } #cities [ selected_number <= 15] { marker-width: 25.0; } #cities [ selected_number <= 8] { marker-width: 23.3; } #cities [ selected_number <= 8] { marker-width: 21.7; } #cities [ selected_number <= 6] { marker-width: 20.0; } #cities [ selected_number <= 6] { marker-width: 18.3; } #cities [ selected_number <= 4] { marker-width: 16.7; } #cities [ selected_number <= 3] { marker-width: 15.0; } #cities [ selected_number <= 2] { marker-width: 13.3; } #cities [ selected_number <= 1] { marker-width: 10.0; } #cities::labels [selected_number>=8][zoom>5], [selected_number>=2][zoom>6], [selected_number>=1][zoom>7] { text-name: [city_name]; text-face-name: 'Open Sans Regular'; text-size: 15; text-fill: #000; text-allow-overlap: true; text-halo-fill: #FFF; text-halo-radius: 1; text-placement-type: simple; text-placements: \"N,S,E,W,NE,SE,NW,SW,16,14,12\"; text-dy: 3; text-dx: 3; }");
 	}
-	
 
-      function main() {
+	function ReverseDisplay(d) {
+	  if(document.getElementById(d).style.display == "none") { document.getElementById(d).style.display = "block"; }
+	  else { document.getElementById(d).style.display = "none"; }
+	}
+	
+	function initalizeObserverOnInfowindowLinks() {
+		// Select the node that will be observed for mutations
+		const targetNode = document.getElementsByClassName('cartodb-infowindow')[0];
+
+		// Options for the observer (which mutations to observe)
+		const config = { childList: true, subtree: true };
+
+		// Callback function to execute when mutations are observed
+		// here we set the href of each link in the infowindow
+		// to call the function ReverseDisplay defined above
+		const callback = function(mutationList, observer) {
+			i = 1;
+			while(document.getElementById('link_to_citation_' + i)) {
+				const link = document.getElementById('link_to_citation_' + i);
+				link.href = `javascript:ReverseDisplay('citation_${i}')`;
+				i++;
+			}
+		};
+
+		// Create an observer instance linked to the callback function
+		const observer = new MutationObserver(callback);
+
+		// Start observing the target node for configured mutations
+		observer.observe(targetNode, config);
+	}
+
+    function main() {
         cartodb.createVis('map', 'https://greeklyricpoets.cartodb.com/api/v2/viz/bebd1b2e-fa45-11e4-a8a0-0e9d821ea90d/viz.json', {
           tiles_loader: true,
           center_lat: 38.9,
@@ -638,6 +639,8 @@
 			
 			createSelector(layers[1]);
 			if(getParameterByName('visited') != 1) createEssay("home");
+
+			initalizeObserverOnInfowindowLinks();
         })
         .error(function(err) {
           console.log(err);

--- a/production/html/imaginary.html
+++ b/production/html/imaginary.html
@@ -216,24 +216,6 @@
     //-->
     </script>
 	
-	<script type="text/javascript" language="JavaScript"><!--
-	function HideContent(d) {
-	  document.getElementById(d).style.display = "none";
-	}
-	function ShowContent(d) {
-	  document.getElementById(d).style.display = "block";
-	}
-	function ReverseDisplay(d) {
-	  if(document.getElementById(d).style.display == "none") { document.getElementById(d).style.display = "block"; }
-	  else { document.getElementById(d).style.display = "none"; }
-/*	  var pane = $("view12 .cartodb-popup-content");
-	  var api = pane.data('jsp');
-	  api.reinitialise(); */
-	}
-	//--></script>
-
-
-	
     <script>
       // create layer selector
       function createSelector(layer) {


### PR DESCRIPTION
For some reason our javascript passed through the SQL query to Carto is being stripped out (perhaps Carto is now worried about javascript SQL injections?). This PR now adds a mutation detector to the Carto infowindow and redirects the Citation links to call the 'ReverseDisplay' function as they did before.

I also cleaned up the ReverseDisplay function and removed it from Imaginary, where it wasn't being used.

Addresses #317 

Tested locally.
<img width="251" alt="image" src="https://user-images.githubusercontent.com/5913839/170838924-6c492420-11e0-462e-b181-5244f0054dd0.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/5913839/170838932-241f6ee0-ee1d-45c3-bb33-65ec66256571.png">
