### PR TITLE
uncomment out observer line

### DIFF
--- a/production/html/bubblemap.html
+++ b/production/html/bubblemap.html
@@ -624,7 +624,7 @@
 		const observer = new MutationObserver(callback);
 
 		// Start observing the target node for configured mutations
-		// observer.observe(targetNode, config);
+		observer.observe(targetNode, config);
 	}
 
     function main() {


### PR DESCRIPTION
Line actually initializing the citation mutation observer was commented out. Uncommenting it initializes the observer and allows the comment links to work as expected.
Closes #329 